### PR TITLE
Update gas limit 750k -> 120k

### DIFF
--- a/gnt2-migration-ui/src/config/config.production.ts
+++ b/gnt2-migration-ui/src/config/config.production.ts
@@ -3,7 +3,7 @@ import {WebConfig} from '../domain/WebConfig';
 
 const getConfig = () => Object.freeze<WebConfig>(
   {
-    gasLimit: Number.parseInt(getEnv('GAS_LIMIT', '750000')),
+    gasLimit: Number.parseInt(getEnv('GAS_LIMIT', '120000')),
     confirmationHeights: {
       local: 1,
       rinkeby: 6,


### PR DESCRIPTION
This will update the gas limit in the config file from 750000 to 120000, which will benefit users by showing a more accurate fee on migration transactions.

PR requested by @tworec, needs review.